### PR TITLE
Fix misspelled CHECK because doesn't work on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 	${RSCRIPT} -e "devtools::test()"
 
 check: build
-	_R_CHECK_CRAN_INCOMING_=FALSE R CMD CHECK --as-cran --no-manual `ls -1tr ${PACKAGE}*gz | tail -n1`
+	_R_CHECK_CRAN_INCOMING_=FALSE R CMD check --as-cran --no-manual `ls -1tr ${PACKAGE}*gz | tail -n1`
 	@rm -f `ls -1tr ${PACKAGE}*gz | tail -n1`
 	@rm -rf ${PACKAGE}.Rcheck
 


### PR DESCRIPTION
`R CMD CHECK` doesn't work on linux. It shold be `R CMD check`.