### PR TITLE
Option 2: Fix loop that goes out of bounds

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -31,7 +31,8 @@ mutate <- function(x) {
   x_length <- length(x)
   for (i in 1:x_length) {
     x[[i]] <- mutate_one(x[[i]])
-    if (attr(x[[i]], "mutated")) break
+    is_done <- attr(x[[i]], "mutated")
+    if (is_done) break
   }
   return(x)
 }

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -28,12 +28,10 @@ mutate <- function(x) {
     attr(z, "mutated") <- FALSE
     z
   })
-  not_done <- TRUE
-  i <- 0
-  while (not_done) {
-    i <- i + 1
+  x_length <- length(x)
+  for (i in 1:x_length) {
     x[[i]] <- mutate_one(x[[i]])
-    if (attr(x[[i]], "mutated")) not_done <- FALSE
+    if (attr(x[[i]], "mutated")) break
   }
   return(x)
 }


### PR DESCRIPTION
This _PR_ is an aternative to #14. 

---

The `i` in the while loop in `mutate` some times gets bigger than the length of `x`. That is a problem in this line:
```
x[[i]] <- mutate_one(x[[i]])
```
since it produces this error:
```
Error in x[[i]] : subscript out of bounds
```
